### PR TITLE
Remove the openssl dependency for easier cross-compilation

### DIFF
--- a/auraxis/Cargo.toml
+++ b/auraxis/Cargo.toml
@@ -12,13 +12,13 @@ serde_json = "1.0.85"
 serde_with = { version = "2.0.0", features = ["chrono"] }
 tracing = "0.1.36"
 tokio = { version = "1.21.0", features = ["sync", "time", "rt", "net", "macros"] }
-tokio-tungstenite = { version = "0.17.2", features = ["connect", "native-tls"] }
+tokio-tungstenite = { version = "0.17.2", features = ["connect", "rustls-tls-webpki-roots"] }
 futures = "0.3.24"
 futures-util = "0.3.24"
 thiserror = "1.0.34"
 num_enum = "0.5.7"
 anyhow = "1.0.64"
-reqwest = { version = "0.11.12", features = ["json"] }
+reqwest = { version = "0.11.12", default-features = false, features = ["json", "rustls-tls"] }
 async-trait = "0.1.58"
 auraxis_macros = {version = "0.1.0", path = "../auraxis_macros"}
 


### PR DESCRIPTION
This PR removes the project's dependency on openssl and replaces it with rustls. This will drastically simplify cross compilation to other platforms. For example I implemented this on https://github.com/brakenium/niumside-poptracker where it greatly simplified my CICD and allowed me to drastically improve compilation times. Not having to use QEMU and Docker to emulate arm architectures helps drastically. Instead I simply used cross-rs and just build Docker images from there.

I can keep making these PR's, but if they won't be merged I might simply work on my own fork from now on to keep things simpler.
